### PR TITLE
modified ASDF definition to use new system name: mass-lexer

### DIFF
--- a/lexer.asd
+++ b/lexer.asd
@@ -1,10 +1,9 @@
-(defpackage :lexer-asd
+(defpackage :mass-lexer-asd
   (:use :cl :asdf))
 
-(in-package :lexer-asd)
+(in-package :mass-lexer-asd)
 
-(defsystem :lexer
-  :name "lexer"
+(defsystem :mass-lexer
   :version "1.0"
   :author "Jeffrey Massung"
   :license "Apache 2.0"


### PR DESCRIPTION
These modifications solve the naming conflict problem but LEXER is still uncompatible with CL implementations other than LispWorks (not to mention that the RE package is not in the Quicklisp repository and therefore this system will not be loaded).

It looks like the main compatibility problem stems from the RE dependence on the [PARSERGEN functionality](http://www.lispworks.com/documentation/lw61/LW/html/lw-314.htm).
